### PR TITLE
Removed singleton usage from Input module

### DIFF
--- a/examples/core/input/0_input_keyboard/main.cpp
+++ b/examples/core/input/0_input_keyboard/main.cpp
@@ -18,7 +18,8 @@ int main() {
         std::cout << "key press\n";
     };
 
-    Input::get_instance().register_key_action(KeyCode::A, key_press);
+    auto input = window->get_input();
+    input->register_key_action(KeyCode::A, key_press);
 
     while (!window->closing()) {
         GLContext::clear_color(0.2f, 0.2f, 0.2f, 1.0f);

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/entity_component_system/components/flying.cpp
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/entity_component_system/components/flying.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 
 namespace game::core::ecs {
-    Flying::Flying(const float& flyForce) : velocityY(0.0f), flyForce(flyForce) {
+    Flying::Flying(const float& flyForce, const shared_ptr<Input>& input) : velocityY(0.0f), flyForce(flyForce), input(input) {
         flyFunction = std::function<void()>([this]() {
             set_velocity(this->flyForce);
         });
@@ -32,11 +32,11 @@ namespace game::core::ecs {
 
     void Flying::enable() {
         Component::enable();
-        Input::get_instance().register_key_action(KeyCode::MouseButtonLeft, flyFunction);
+        input->register_key_action(KeyCode::MouseButtonLeft, flyFunction);
     }
 
     void Flying::disable() {
         Component::disable();
-        Input::get_instance().remove_key_action(KeyCode::MouseButtonLeft, flyFunction);
+        input->remove_key_action(KeyCode::MouseButtonLeft, flyFunction);
     }
 }

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/entity_component_system/components/flying.h
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/entity_component_system/components/flying.h
@@ -24,10 +24,12 @@ namespace game::core::ecs {
             float minRotZ = -85.0f;
             float maxRotZ = 25.0f;
 
+            std::shared_ptr<Input> input;
+
             std::function<void()> flyFunction;
             
         public:
-            explicit Flying(const float& flyForce);
+            explicit Flying(const float& flyForce, const std::shared_ptr<Input>& input);
 
             void update() override;
 

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/end_game_state.cpp
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/end_game_state.cpp
@@ -5,7 +5,7 @@
 #include "../../score.h"
 
 namespace game::core::fsm {
-    EndGameState::EndGameState(shared_ptr<GameObject> flappyBird) : menuState(nullptr), flappyBird(std::move(flappyBird)) {
+    EndGameState::EndGameState(shared_ptr<GameObject> flappyBird, const shared_ptr<Input>& input) : menuState(nullptr), flappyBird(std::move(flappyBird)), input(input) {
         transitionFunction = [this]() {
             StateMachine::set_state(menuState);
         };
@@ -20,11 +20,11 @@ namespace game::core::fsm {
         cout << "Game Over" << endl;
         cout << "Your score: " << Score::get_score() << endl;
 
-        Input::get_instance().register_key_action(KeyCode::MouseButtonLeft, transitionFunction);
+        input->register_key_action(KeyCode::MouseButtonLeft, transitionFunction);
     }
 
     void EndGameState::exit() {
-        Input::get_instance().remove_key_action(KeyCode::MouseButtonLeft, transitionFunction);
+        input->remove_key_action(KeyCode::MouseButtonLeft, transitionFunction);
         Score::clear();
     }
 

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/end_game_state.h
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/end_game_state.h
@@ -18,10 +18,11 @@ namespace game::core::fsm {
         private:
             shared_ptr<State> menuState;
             shared_ptr<GameObject> flappyBird;
+            shared_ptr<Input> input;
 
             std::function<void()> transitionFunction;
         public:
-            EndGameState(shared_ptr<GameObject> flappyBird);
+            EndGameState(shared_ptr<GameObject> flappyBird, const shared_ptr<Input>& input);
             ~EndGameState() override;
 
             void enter() override;

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/game_state.cpp
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/game_state.cpp
@@ -12,7 +12,9 @@
 namespace game::core::fsm {
     #define FLY_FORCE 0.06f
 
-    GameState::GameState(const shared_ptr<GameObject>& flappyBird) : endGameState(nullptr), flappyBird(flappyBird) {
+    GameState::GameState(const shared_ptr<GameObject>& flappyBird, const shared_ptr<Input>& input)
+        : endGameState(nullptr), flappyBird(flappyBird), input(input) {
+
         ground1 = Game::find_game_object_by_name("Ground1");
         ground2 = Game::find_game_object_by_name("Ground2");
         pipe1 = Game::find_game_object_by_name("Pipe1");
@@ -46,7 +48,7 @@ namespace game::core::fsm {
         pipe1->add_component<Collider>(emptySpaceTriggerTopLeftPoint, emptySpaceTriggerBottomRightPoint, true);
         pipe2->add_component<Collider>(emptySpaceTriggerTopLeftPoint, emptySpaceTriggerBottomRightPoint, true);
 
-        flappyBird->add_component<Flying>(FLY_FORCE)->disable();
+        flappyBird->add_component<Flying>(FLY_FORCE, input)->disable();
         
         auto flappyBirdSprite = flappyBird->get_component<SpriteRenderer>()->get_sprite();
         Vec2f flappyBirdColliderTopLeftPoint = { -flappyBirdSprite->get_unit_width() / 2.0f, flappyBirdSprite->get_unit_height() / 2.0f };

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/game_state.h
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/game_state.h
@@ -22,6 +22,8 @@ namespace game::core::fsm {
             shared_ptr<GameObject> pipe1;
             shared_ptr<GameObject> pipe2;
 
+            shared_ptr<Input> input;
+
             float groundY;
             float airY;
 
@@ -29,7 +31,7 @@ namespace game::core::fsm {
 
             void transition_to_end_game_state();
         public:
-            explicit GameState(const shared_ptr<GameObject>& flappyBird);
+            explicit GameState(const shared_ptr<GameObject>& flappyBird, const shared_ptr<Input>& input);
             ~GameState() override;
 
             void enter() override;

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/main_menu_state.cpp
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/main_menu_state.cpp
@@ -6,7 +6,9 @@
 #include "../../rng.h"
 
 namespace game::core::fsm {
-    MainMenuState::MainMenuState(shared_ptr<GameObject> flappyBird) : gameState(nullptr), flappyBird(std::move(flappyBird)) {
+    MainMenuState::MainMenuState(shared_ptr<GameObject> flappyBird, const shared_ptr<Input>& input)
+        : gameState(nullptr), flappyBird(std::move(flappyBird)), input(input) {
+
         transitionFunction = std::function<void()>([this]() {
             StateMachine::set_state(gameState);
         });
@@ -24,11 +26,11 @@ namespace game::core::fsm {
         Game::find_game_object_by_name("Pipe1")->get_transform()->set_position(Vec3f(6.2f, Random::rand(-3.0f, 4.5f), 2.0f));
         Game::find_game_object_by_name("Pipe2")->get_transform()->set_position(Vec3f(12.0f, Random::rand(-3.0f, 4.5f), 2.0f));
 
-        Input::get_instance().register_key_action(KeyCode::MouseButtonLeft, transitionFunction);
+        input->register_key_action(KeyCode::MouseButtonLeft, transitionFunction);
     }
 
     void MainMenuState::exit() {
-        Input::get_instance().remove_key_action(KeyCode::MouseButtonLeft, transitionFunction);
+        input->remove_key_action(KeyCode::MouseButtonLeft, transitionFunction);
     }
 
     void MainMenuState::set_game_state(shared_ptr<State> gameState) {

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/main_menu_state.h
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/finite_state_machine/states/main_menu_state.h
@@ -18,10 +18,11 @@ namespace game::core::fsm {
         private:
             shared_ptr<State> gameState;
             shared_ptr<GameObject> flappyBird;
+            shared_ptr<Input> input;
 
             std::function<void()> transitionFunction;
         public:
-            MainMenuState(shared_ptr<GameObject> flappyBird);
+            MainMenuState(shared_ptr<GameObject> flappyBird, const shared_ptr<Input>& input);
             ~MainMenuState() override;
 
             void enter() override;

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/game.cpp
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/game.cpp
@@ -13,7 +13,7 @@ namespace game::core {
 
     vector<shared_ptr<GameObject>> Game::gameObjects = vector<shared_ptr<GameObject>>();
 
-    Game::Game(const unsigned int& width, const unsigned int& height) {
+    Game::Game(const unsigned int& width, const unsigned int& height, const shared_ptr<Input>& input) : input(input) {
         const auto aspect = static_cast<f32>(width) / static_cast<f32>(height);
 
         camera = make_shared<OrthographicCamera>(aspect * -7.0f, aspect * 7.0f, 7.0, -7.0, -7.0f, 7.0f);
@@ -63,9 +63,9 @@ namespace game::core {
         batch->add(pipe2);
         pipe2->get_transform()->set_scale(0.5f);
 
-        mainMenuState = make_shared<MainMenuState>(flappyBird);
-        gameState = make_shared<GameState>(flappyBird);
-        endGameState = make_shared<EndGameState>(flappyBird);
+        mainMenuState = make_shared<MainMenuState>(flappyBird, input);
+        gameState = make_shared<GameState>(flappyBird, input);
+        endGameState = make_shared<EndGameState>(flappyBird, input);
         
         mainMenuState->set_game_state(gameState);
         gameState->set_end_game_state(endGameState);

--- a/examples/gfx/opengl/5_opengl_flappy_bird/core/game.h
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/core/game.h
@@ -31,6 +31,8 @@ namespace game::core {
             shared_ptr<GameState> gameState;
             shared_ptr<EndGameState> endGameState;
 
+            shared_ptr<Input> input;
+
             static vector<shared_ptr<GameObject>> gameObjects;
 
             shared_ptr<GameObject> instantiate(const string& gameObjectName, const Vec3f& position = {0.0f, 0.0f, 0.0f});
@@ -38,7 +40,7 @@ namespace game::core {
 
             void update_game_objects();
         public:
-            Game(const unsigned int& width, const unsigned int& height);
+            Game(const unsigned int& width, const unsigned int& height, const shared_ptr<Input>& input);
             void update();
 
             static shared_ptr<GameObject> find_game_object_by_name(const string& gameObjectName);

--- a/examples/gfx/opengl/5_opengl_flappy_bird/main.cpp
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/main.cpp
@@ -27,7 +27,8 @@ int main() {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    Game game(SCR_WIDTH, SCR_HEIGHT);
+    auto input = window->get_input();
+    Game game(SCR_WIDTH, SCR_HEIGHT, input);
 
     double beginTime = Time::get_time();
     double endTime;

--- a/src/bebone/core/core.h
+++ b/src/bebone/core/core.h
@@ -17,6 +17,5 @@
 
 // Input
 #include "input/input.h"
-#include "input/input_handler.h"
 
 #endif

--- a/src/bebone/core/events/listeners/event_listener.tpp
+++ b/src/bebone/core/events/listeners/event_listener.tpp
@@ -4,7 +4,7 @@
 #include "event.tpp"
 
 namespace bebone::core {
-    using namespace std;
+    // using namespace std;
 
     /*!
      * Base class for all event listeners

--- a/src/bebone/core/input/input.cpp
+++ b/src/bebone/core/input/input.cpp
@@ -1,12 +1,6 @@
 #include "input.h"
 
 namespace bebone::core {
-    Input& Input::get_instance() {
-        static Input instance;
-
-        return instance;
-    }
-
     void Input::register_key_action(const KeyCode& key_code, std::function<void()>& action, const InputType& input_type) {
         const Key key(key_code, input_type);
 

--- a/src/bebone/core/input/input.h
+++ b/src/bebone/core/input/input.h
@@ -21,19 +21,10 @@ namespace bebone::core {
             map<Key, BeboneAction> key_actions;
             queue<Key> queued_keys;
 
-            Input() = default;
-
             void queue_key(const KeyCode& key_code, const InputType& input_type);
             void execute_queued_actions();
 
         public:
-            Input(const Input& obj) = delete;
-            void operator=(Input const& obj) = delete;
-
-            /// Returns singleton reference to the input system object
-            /// @return Input system object reference
-            static Input& get_instance();
-
             /*!
             * Registers the key to do specific action
             * 
@@ -53,8 +44,8 @@ namespace bebone::core {
             void remove_key_action(const KeyCode& key_code, std::function<void()>& action, const InputType& input_type = InputType::Press);
 
             friend class InputHandler;
-            friend struct KeyListener;
-            friend struct MouseListener;
+            friend class KeyListener;
+            friend class MouseListener;
     };
 }
 

--- a/src/bebone/core/input/input_handler.cpp
+++ b/src/bebone/core/input/input_handler.cpp
@@ -1,6 +1,8 @@
 #include "input_handler.h"
 
 namespace bebone::core {
+    InputHandler::InputHandler() : input(std::make_shared<Input>()), key_listener(input), mouse_listener(input) {}
+
     const KeyListener& InputHandler::get_key_listener() const {
         return key_listener;
     }
@@ -10,6 +12,6 @@ namespace bebone::core {
     }
 
     void InputHandler::execute_input_actions() const {
-        Input::get_instance().execute_queued_actions();
+        input->execute_queued_actions();
     }
 }

--- a/src/bebone/core/input/input_handler.cpp
+++ b/src/bebone/core/input/input_handler.cpp
@@ -14,4 +14,8 @@ namespace bebone::core {
     void InputHandler::execute_input_actions() const {
         input->execute_queued_actions();
     }
+
+    std::shared_ptr<Input> InputHandler::get_input() const {
+        return input;
+    }
 }

--- a/src/bebone/core/input/input_handler.h
+++ b/src/bebone/core/input/input_handler.h
@@ -24,6 +24,8 @@ namespace bebone::core {
 
             // Executes all input actions
             void execute_input_actions() const;
+
+            std::shared_ptr<Input> get_input() const;
     };
 }
 

--- a/src/bebone/core/input/input_handler.h
+++ b/src/bebone/core/input/input_handler.h
@@ -9,15 +9,18 @@ namespace bebone::core {
     // Input handler class
     class InputHandler {
         private:
+            std::shared_ptr<Input> input;
             KeyListener key_listener;
             MouseListener mouse_listener;
 
         public:
+            InputHandler();
+
             // Getter for key listener
-            const KeyListener& get_key_listener() const;
+            [[nodiscard]] const KeyListener& get_key_listener() const;
 
             // Getter for mouse listener
-            const MouseListener& get_mouse_listener() const;
+            [[nodiscard]] const MouseListener& get_mouse_listener() const;
 
             // Executes all input actions
             void execute_input_actions() const;

--- a/src/bebone/core/input/key_listener.cpp
+++ b/src/bebone/core/input/key_listener.cpp
@@ -1,0 +1,11 @@
+#include "key_listener.h"
+
+namespace bebone::core {
+    KeyListener::KeyListener(std::shared_ptr<Input> &input) : input(input) {}
+
+    void KeyListener::operator()(gfx::InputKeyEvent &event) {
+        const auto key_code = static_cast<KeyCode>(event.key);
+        const auto input_type = static_cast<InputType>(event.action);
+        input->queue_key(key_code, input_type);
+    }
+}

--- a/src/bebone/core/input/key_listener.h
+++ b/src/bebone/core/input/key_listener.h
@@ -7,19 +7,18 @@
 
 #include "input.h"
 
-#include <iostream>
-
 namespace bebone::core {
     using namespace gfx;
 
-    struct KeyListener : EventListener<InputKeyEvent> {
-        void operator()(InputKeyEvent& event) override {
-            Input& input = Input::get_instance();
+    class KeyListener : EventListener<InputKeyEvent> {
+    private:
+        std::shared_ptr<Input>& input;
 
-            const auto key_code = static_cast<KeyCode>(event.key);
-            const auto input_type = static_cast<InputType>(event.action);
-            input.queue_key(key_code, input_type);
-        }
+    public:
+        KeyListener() = delete;
+        explicit KeyListener(std::shared_ptr<Input>& input);
+
+        void operator()(InputKeyEvent& event) override;
     };
 }
 

--- a/src/bebone/core/input/mouse_listener.cpp
+++ b/src/bebone/core/input/mouse_listener.cpp
@@ -1,0 +1,11 @@
+#include "mouse_listener.h"
+
+namespace bebone::core {
+    MouseListener::MouseListener(std::shared_ptr<Input>& input) : input(input) { }
+
+    void MouseListener::operator()(InputMouseButtonEvent &event) {
+        const auto key_code = static_cast<KeyCode>(event.button);
+        const auto input_type = static_cast<InputType>(event.action);
+        input->queue_key(key_code, input_type);
+    }
+}

--- a/src/bebone/core/input/mouse_listener.h
+++ b/src/bebone/core/input/mouse_listener.h
@@ -10,14 +10,15 @@
 namespace bebone::core {
     using namespace gfx;
 
-    struct MouseListener : EventListener<InputMouseButtonEvent> {
-        void operator()(InputMouseButtonEvent& event) override {
-            Input& input = Input::get_instance();
+    class MouseListener : EventListener<InputMouseButtonEvent> {
+    private:
+        std::shared_ptr<Input>& input;
 
-            const auto key_code = static_cast<KeyCode>(event.button);
-            const auto input_type = static_cast<InputType>(event.action);
-            input.queue_key(key_code, input_type);
-        }
+    public:
+        MouseListener() = delete;
+        explicit MouseListener(std::shared_ptr<Input>& input);
+
+        void operator()(InputMouseButtonEvent& event) override;
     };
 }
 

--- a/src/bebone/gfx/window/window.cpp
+++ b/src/bebone/gfx/window/window.cpp
@@ -118,4 +118,8 @@ namespace bebone::gfx {
     void Window::execute_input_actions() const {
         input_handler.execute_input_actions();
     }
+
+    std::shared_ptr<Input> Window::get_input() const {
+        return input_handler.get_input();
+    }
 }

--- a/src/bebone/gfx/window/window.h
+++ b/src/bebone/gfx/window/window.h
@@ -68,6 +68,9 @@ namespace bebone::gfx {
             /// Function that executes all queued input actions
             void execute_input_actions() const;
 
+            // TODO: we need to refactor this. I really don't like the idea of a window controlling the input
+            std::shared_ptr<Input> get_input() const;
+
         private:
             /// GLFW window position change callbacks
             static void glfw_window_pos_callback(GLFWwindow* glfw_window, int x_pos, int y_pos);

--- a/src/bebone/gfx/window/window.h
+++ b/src/bebone/gfx/window/window.h
@@ -12,6 +12,8 @@
 #include "window_properties.h"
 #include "window_handler.h"
 
+#include "../../core/input/input_handler.h"
+
 namespace bebone::gfx {
     using namespace core;
 


### PR DESCRIPTION
Singleton usage from Input module successfully removed. It changed to dependency injection pattern, which is more reliable.

But these changes leads to the further problems in our code. Now window fully controls the input and don't really like it. From my point of view, the window has a lot of functionality, and registering input is not the responsibility of this class.

I think we need to create another class (for example, Application class) that will create the window, input and other core related classes and store them. I will try to experiment with it in another branch.