### PR TITLE
Removed InputHandler field from Window class

### DIFF
--- a/examples/core/input/0_input_keyboard/main.cpp
+++ b/examples/core/input/0_input_keyboard/main.cpp
@@ -18,14 +18,18 @@ int main() {
         std::cout << "key press\n";
     };
 
-    auto input = window->get_input();
+    InputHandler input_handler = InputHandler();
+    window->add_listener(input_handler.get_key_listener());
+    window->add_listener(input_handler.get_mouse_listener());
+
+    auto input = input_handler.get_input();
     input->register_key_action(KeyCode::A, key_press);
 
     while (!window->closing()) {
         GLContext::clear_color(0.2f, 0.2f, 0.2f, 1.0f);
         GLContext::clear(GL_COLOR_BUFFER_BIT);
 
-        window->execute_input_actions();
+        input_handler.execute_input_actions();
 
         glfwSwapBuffers(window->get_backend());
         glfwPollEvents();

--- a/examples/core/input/0_input_keyboard/main.cpp
+++ b/examples/core/input/0_input_keyboard/main.cpp
@@ -18,7 +18,7 @@ int main() {
         std::cout << "key press\n";
     };
 
-    InputHandler input_handler = InputHandler();
+    InputHandler input_handler;
     window->add_listener(input_handler.get_key_listener());
     window->add_listener(input_handler.get_mouse_listener());
 

--- a/examples/gfx/opengl/5_opengl_flappy_bird/main.cpp
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/main.cpp
@@ -27,7 +27,7 @@ int main() {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    InputHandler input_handler = InputHandler();
+    InputHandler input_handler;
 
     window->add_listener(input_handler.get_key_listener());
     window->add_listener(input_handler.get_mouse_listener());

--- a/examples/gfx/opengl/5_opengl_flappy_bird/main.cpp
+++ b/examples/gfx/opengl/5_opengl_flappy_bird/main.cpp
@@ -27,8 +27,12 @@ int main() {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    auto input = window->get_input();
-    Game game(screen_width, screen_height, input);
+    InputHandler input_handler = InputHandler();
+
+    window->add_listener(input_handler.get_key_listener());
+    window->add_listener(input_handler.get_mouse_listener());
+
+    Game game(screen_width, screen_height, input_handler.get_input());
 
     double begin_time = Time::get_time();
     double end_time;
@@ -37,7 +41,7 @@ int main() {
         GLContext::clear_color(0.2f, 0.2f, 0.2f, 1.0f);
         GLContext::clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-        window->execute_input_actions();
+        input_handler.execute_input_actions();
 
         if (Time::delta_time >= 0) {
             game.update();

--- a/src/bebone/gfx/window/window.cpp
+++ b/src/bebone/gfx/window/window.cpp
@@ -30,9 +30,6 @@ namespace bebone::gfx {
         glfwSetMouseButtonCallback(window, glfw_mouse_button_callback);
         glfwSetKeyCallback(window, glfw_key_callback);
 
-        add_listener(input_handler.get_key_listener());
-        add_listener(input_handler.get_mouse_listener());
-
         add_listener(window_handler.get_window_size_listener());
     }
 
@@ -113,13 +110,5 @@ namespace bebone::gfx {
 
     f32 Window::get_aspect() const {
         return static_cast<f32>(width) / static_cast<f32>(height);
-    }
-
-    void Window::execute_input_actions() const {
-        input_handler.execute_input_actions();
-    }
-
-    std::shared_ptr<Input> Window::get_input() const {
-        return input_handler.get_input();
     }
 }

--- a/src/bebone/gfx/window/window.h
+++ b/src/bebone/gfx/window/window.h
@@ -22,7 +22,6 @@ namespace bebone::gfx {
         private:
             GLFWwindow* window;
 
-            InputHandler input_handler;
             WindowHandler window_handler;
 
         protected:
@@ -64,12 +63,6 @@ namespace bebone::gfx {
 
             /// Function returns glfw window backend
             GLFWwindow* get_backend() const;
-
-            /// Function that executes all queued input actions
-            void execute_input_actions() const;
-
-            // TODO: we need to refactor this. I really don't like the idea of a window controlling the input
-            std::shared_ptr<Input> get_input() const;
 
         private:
             /// GLFW window position change callbacks


### PR DESCRIPTION
I made small changes to the Window class code. Removed InputHandler field from Window class.
Now we need to create InputHandler object separately and add listeners by ourselves. It gives more control over input registration.

In the future plans, I will refactor Input class. I think we can move the input queue elsewhere. I will try to experiment with this in another branch